### PR TITLE
fix: blacklist add bug fix; updated env var typing

### DIFF
--- a/src/commands/Relay/blacklist.ts
+++ b/src/commands/Relay/blacklist.ts
@@ -89,10 +89,17 @@ export class Command extends AmanekoSubcommand {
 			throw new AmanekoError('Channel is already blacklisted.');
 		}
 
-		const data = await this.container.prisma.blacklist.upsert({
-			where: { channelId_guildId: { channelId: idToBlacklist, guildId: interaction.guildId } },
-			update: { channelId: idToBlacklist, channelName },
-			create: { guildId: interaction.guildId, channelId: idToBlacklist, channelName },
+		const data = await this.container.prisma.blacklist.create({
+			data: {
+				guild: {
+					connectOrCreate: {
+						where: { id: interaction.guildId },
+						create: { id: interaction.guildId }
+					}
+				},
+				channelId: idToBlacklist,
+				channelName
+			},
 			select: { channelName: true, channelId: true }
 		});
 

--- a/src/lib/types/environment.ts
+++ b/src/lib/types/environment.ts
@@ -10,6 +10,10 @@ declare global {
 			REDIS_PORT: string | undefined;
 			REDIS_PASSWORD: string | undefined;
 			YOUTUBE_API_KEY: string | undefined;
+			DISCORD_DEVSERVER: string | undefined;
+			DISCORD_OWNERIDS: string | undefined;
+			MEILI_HOST: string | undefined;
+			MEILI_PORT: string | undefined;
 		}
 	}
 }


### PR DESCRIPTION
Adding a blacklist entry now also creates a guild record if needed.

Doesn't check for impossible outcomes anymore (new entries are never equal to previous entries).

New environment variables are typed.